### PR TITLE
Add logging if we fail to retrieve issue/comments from Jira

### DIFF
--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -12,10 +12,10 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.1" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
-
 </Project>

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using NSubstitute;
 using NUnit.Framework;
-using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.HostServices.Model.PackageMetadata;
 using Octopus.Server.Extensibility.IssueTracker.Jira.Configuration;
 using Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems;
@@ -30,7 +29,6 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
             var store = Substitute.For<IJiraConfigurationStore>();
             var jiraClient = Substitute.For<IJiraRestClient>();
             var jiraClientLazy = new Lazy<IJiraRestClient>(() => jiraClient);
-            var log = Substitute.For<ILog>();
             jiraClient.GetIssue(Arg.Is(linkData)).Returns(new JiraIssue
             {
                 Fields = new JiraIssueFields
@@ -56,7 +54,6 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
             var store = Substitute.For<IJiraConfigurationStore>();
             var jiraClient = Substitute.For<IJiraRestClient>();
             var jiraClientLazy = new Lazy<IJiraRestClient>(() => jiraClient);
-            var log = Substitute.For<ILog>();
             store.GetBaseUrl().Returns("https://github.com");
             store.GetIsEnabled().Returns(true);
             jiraClient.GetIssueComments(Arg.Is("JRE-1234")).Returns(new JiraIssueComments

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NSubstitute;
 using NUnit.Framework;
+using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.HostServices.Model.PackageMetadata;
 using Octopus.Server.Extensibility.IssueTracker.Jira.Configuration;
 using Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems;
@@ -29,6 +30,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
             var store = Substitute.For<IJiraConfigurationStore>();
             var jiraClient = Substitute.For<IJiraRestClient>();
             var jiraClientLazy = new Lazy<IJiraRestClient>(() => jiraClient);
+            var log = Substitute.For<ILog>();
             jiraClient.GetIssue(Arg.Is(linkData)).Returns(new JiraIssue
             {
                 Fields = new JiraIssueFields
@@ -54,6 +56,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
             var store = Substitute.For<IJiraConfigurationStore>();
             var jiraClient = Substitute.For<IJiraRestClient>();
             var jiraClientLazy = new Lazy<IJiraRestClient>(() => jiraClient);
+            var log = Substitute.For<ILog>();
             store.GetBaseUrl().Returns("https://github.com");
             store.GetIsEnabled().Returns(true);
             jiraClient.GetIssueComments(Arg.Is("JRE-1234")).Returns(new JiraIssueComments

--- a/source/Server/Integration/JiraRestClient.cs
+++ b/source/Server/Integration/JiraRestClient.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Octopus.Diagnostics;
 
 namespace Octopus.Server.Extensibility.IssueTracker.Jira.Integration
 {
@@ -15,11 +16,13 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Integration
         private readonly AuthenticationHeaderValue AuthorizationHeader;
         
         private readonly string baseUrl;
+        private readonly ILog log;
         private readonly string baseApiUri = "rest/api/2";
 
-        public JiraRestClient(string baseUrl, string username, string password)
+        public JiraRestClient(string baseUrl, string username, string password, ILog log)
         {
             this.baseUrl = baseUrl;
+            this.log = log;
             AuthorizationHeader = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}")));
         }
 
@@ -34,6 +37,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Integration
                     return result;
                 }
 
+                log.Warn($"Failed to retrieve Jira issue '{workItemId}' from {baseUrl}. Status Code: {response.StatusCode}{(!string.IsNullOrEmpty(response.ReasonPhrase) ? $" (Reason: {response.ReasonPhrase})": "")}");
                 return null;
             }
         }
@@ -45,6 +49,8 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Integration
                 var response = await client.GetAsync($"{baseUrl}/{baseApiUri}/issue/{workItemId}/comment");
                 if (response.IsSuccessStatusCode)
                     return JsonConvert.DeserializeObject<JiraIssueComments>(await response.Content.ReadAsStringAsync());
+
+                log.Warn($"Failed to retrieve comments for Jira issue '{workItemId}' from {baseUrl}. Status Code: {response.StatusCode}{(!string.IsNullOrEmpty(response.ReasonPhrase) ? $" (Reason: {response.ReasonPhrase})": "")}");
                 return new JiraIssueComments();
             }
         }

--- a/source/Server/JiraIssueTrackerExtension.cs
+++ b/source/Server/JiraIssueTrackerExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Autofac;
+using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Extensions;
 using Octopus.Server.Extensibility.Extensions.Infrastructure;
 using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
@@ -60,7 +61,8 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira
                 var baseUrl = store.GetBaseUrl();
                 var username = store.GetJiraUsername();
                 var password = store.GetJiraPassword();
-                return new JiraRestClient(baseUrl, username, password);
+                var log = c.Resolve<ILog>();
+                return new JiraRestClient(baseUrl, username, password, log);
             }).As<IJiraRestClient>()
             .InstancePerDependency();
         }


### PR DESCRIPTION
To aid troubleshooting connection issues when pulling release notes for issues from Jira

This will log a warning to the Octopus server logs, and will show up under `Configuration -> Diagnostics`
![image](https://user-images.githubusercontent.com/1035315/60941699-5f537a80-a323-11e9-9457-327a5c0b381b.png)
