### PR TITLE
Support failure warnings in IWorkItemLinkMapper.Map()

### DIFF
--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0004" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 </Project>

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0001" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0003" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 </Project>

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0004" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.0" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 </Project>

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.1" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0001" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 </Project>

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -73,7 +73,8 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
                 }
             });
 
-            Assert.AreEqual(1, workItems.Length);
+            Assert.IsTrue(workItems.Succeeded);
+            Assert.AreEqual(1, workItems.Value.Length);
         }
     }
 }

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Octopus.Data" Version="4.1.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0001" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0003" />
     <PackageReference Include="Octopus.Shared" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Octopus.Data" Version="4.1.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.1" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0001" />
     <PackageReference Include="Octopus.Shared" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Octopus.Data" Version="4.1.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0004" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.0" />
     <PackageReference Include="Octopus.Shared" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Octopus.Data" Version="4.1.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0004" />
     <PackageReference Include="Octopus.Shared" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Octopus.Server.Extensibility.Extensions;
 using Octopus.Server.Extensibility.Extensions.WorkItems;
 using Octopus.Server.Extensibility.HostServices.Model.PackageMetadata;
 using Octopus.Server.Extensibility.IssueTracker.Jira.Configuration;
@@ -27,7 +28,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems
         public string CommentParser => JiraConfigurationStore.CommentParser;
         public bool IsEnabled => store.GetIsEnabled();
 
-        public WorkItemLink[] Map(OctopusPackageMetadata packageMetadata)
+        public ExtResult<WorkItemLink[]> Map(OctopusPackageMetadata packageMetadata)
         {
             if (packageMetadata.CommentParser != CommentParser)
                 return null;

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -28,7 +28,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems
         public string CommentParser => JiraConfigurationStore.CommentParser;
         public bool IsEnabled => store.GetIsEnabled();
 
-        public ExtResult<WorkItemLink[]> Map(OctopusPackageMetadata packageMetadata)
+        public SuccessOrErrorResult<WorkItemLink[]> Map(OctopusPackageMetadata packageMetadata)
         {
             if (packageMetadata.CommentParser != CommentParser)
                 return null;


### PR DESCRIPTION
Responds to an API change in OctopusDeploy/ServerExtensibility#20. No change to behaviour.