### PR TITLE
Update work item parsing and display of work items in Octopus

### DIFF
--- a/source/Server.Tests/CommentParserScenarios.cs
+++ b/source/Server.Tests/CommentParserScenarios.cs
@@ -74,8 +74,12 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
         [TestCase("Some text test-foo-2")]
         [TestCase("Some text test-foo-2-bar")]
         [TestCase("Some text test-foo-")]
-        [TestCase("Merge branch 'master' of http://tst-01.com")]
         [TestCase("Something $foo-1")]
+        // Due to relaxing the RegEx used to parse issues from comments this test case is no longer valid,
+        // it's handled by us checking with the Jira instance if the issue exists, or if it doesnt exist
+        // it doesn't get included in the list of work items returned to the UI
+        // See https://github.com/OctopusDeploy/JiraIssueTracker/issues/12 for more context
+        // [TestCase("Merge branch 'master' of http://tst-01.com")]
         public void CommentsWithStringThatLookCloseToReferencesGetParsedCorrectly(string comment)
         {
             var workItemReferences = new CommentParser().ParseWorkItemIds(Create(comment));

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -29,7 +29,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
             var store = Substitute.For<IJiraConfigurationStore>();
             var jiraClient = Substitute.For<IJiraRestClient>();
             var jiraClientLazy = new Lazy<IJiraRestClient>(() => jiraClient);
-            jiraClient.GetIssue(Arg.Is(linkData)).Returns(new JiraIssue
+            var jiraIssue = new JiraIssue
             {
                 Fields = new JiraIssueFields
                 {
@@ -39,13 +39,14 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
                         Total = 1
                     }
                 }
-            });
+            };
+            jiraClient.GetIssue(Arg.Is(linkData)).Returns(jiraIssue);
             jiraClient.GetIssueComments(Arg.Is(linkData)).Returns(new JiraIssueComments
             {
                 Comments = new [] {new JiraIssueComment { Body = releaseNote }}
             });
 
-            return new WorkItemLinkMapper(store, new CommentParser(), jiraClientLazy).GetReleaseNote(linkData, releaseNotePrefix);
+            return new WorkItemLinkMapper(store, new CommentParser(), jiraClientLazy).GetReleaseNote(jiraIssue,linkData, releaseNotePrefix);
         }
 
         [Test]
@@ -56,6 +57,9 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
             var jiraClientLazy = new Lazy<IJiraRestClient>(() => jiraClient);
             store.GetBaseUrl().Returns("https://github.com");
             store.GetIsEnabled().Returns(true);
+            store.GetJiraUsername().Returns("user");
+            store.GetJiraPassword().Returns("password");
+            jiraClient.GetIssue(Arg.Is("JRE-1234")).Returns(new JiraIssue());
             jiraClient.GetIssueComments(Arg.Is("JRE-1234")).Returns(new JiraIssueComments
             {
                 Comments = new [] {new JiraIssueComment { Body = string.Empty }}

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -31,6 +31,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
             var jiraClientLazy = new Lazy<IJiraRestClient>(() => jiraClient);
             var jiraIssue = new JiraIssue
             {
+                Key = linkData,
                 Fields = new JiraIssueFields
                 {
                     Summary = "Test title",
@@ -46,7 +47,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
                 Comments = new [] {new JiraIssueComment { Body = releaseNote }}
             });
 
-            return new WorkItemLinkMapper(store, new CommentParser(), jiraClientLazy).GetReleaseNote(jiraIssue,linkData, releaseNotePrefix);
+            return new WorkItemLinkMapper(store, new CommentParser(), jiraClientLazy).GetReleaseNote(jiraIssue, releaseNotePrefix);
         }
 
         [Test]

--- a/source/Server/Integration/JiraRestClient.cs
+++ b/source/Server/Integration/JiraRestClient.cs
@@ -86,6 +86,8 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Integration
             Fields = new JiraIssueFields();
         }
         
+        [JsonProperty("key")]
+        public string Key { get; set; }
         [JsonProperty("fields")]
         public JiraIssueFields Fields { get; set; }
     }

--- a/source/Server/Integration/JiraRestClient.cs
+++ b/source/Server/Integration/JiraRestClient.cs
@@ -37,7 +37,12 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Integration
                     return result;
                 }
 
-                log.Warn($"Failed to retrieve Jira issue '{workItemId}' from {baseUrl}. Status Code: {response.StatusCode}{(!string.IsNullOrEmpty(response.ReasonPhrase) ? $" (Reason: {response.ReasonPhrase})": "")}");
+                var msg =
+                    $"Failed to retrieve Jira issue '{workItemId}' from {baseUrl}. Status Code: {response.StatusCode}{(!string.IsNullOrEmpty(response.ReasonPhrase) ? $" (Reason: {response.ReasonPhrase})" : "")}";
+                if(response.StatusCode == HttpStatusCode.NotFound)
+                    log.Trace(msg);
+                else
+                    log.Warn(msg);
                 return null;
             }
         }
@@ -50,7 +55,12 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Integration
                 if (response.IsSuccessStatusCode)
                     return JsonConvert.DeserializeObject<JiraIssueComments>(await response.Content.ReadAsStringAsync());
 
-                log.Warn($"Failed to retrieve comments for Jira issue '{workItemId}' from {baseUrl}. Status Code: {response.StatusCode}{(!string.IsNullOrEmpty(response.ReasonPhrase) ? $" (Reason: {response.ReasonPhrase})": "")}");
+                var msg =
+                    $"Failed to retrieve comments for Jira issue '{workItemId}' from {baseUrl}. Status Code: {response.StatusCode}{(!string.IsNullOrEmpty(response.ReasonPhrase) ? $" (Reason: {response.ReasonPhrase})" : "")}";
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                    log.Trace(msg);
+                else
+                    log.Warn(msg);
                 return new JiraIssueComments();
             }
         }

--- a/source/Server/WorkItems/CommentParser.cs
+++ b/source/Server/WorkItems/CommentParser.cs
@@ -7,17 +7,8 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems
     public class CommentParser
     {
         // Expression based on example found here https://confluence.atlassian.com/stashkb/integrating-with-custom-jira-issue-key-313460921.html?_ga=2.163394108.1696841245.1556699049-1954949426.1532303954 with modified negative lookbehind
-        // Explanation:
-        // Negative Lookbehind (?<!([\041-\053\056-\176]{1,10})-?)
-        // Assert that the Regex below does not match
-        //  2nd Capturing Group ([\041-\053\056-\176]{1,10})
-        //   Match a single character present in the list below [\041-\053\056-\176]{1,10}
-        //   {1,10} Quantifier — Matches between 1 and 10 times, as many times as possible, giving back as needed (greedy)
-        //   \041-\053 a single character in the range between ! (index 33) and + (index 43) (case insensitive)
-        //   \056-\176 a single character in the range between . (index 46) and ~ (index 126) (case insensitive)
-        //  -? matches the character - literally (case insensitive)
-        //   ? Quantifier — Matches between zero and one times, as many times as possible, giving back as needed (greedy)
-        private static readonly Regex Expression = new Regex("((?<!([\\041-\\053\\056-\\176]{1,10})-?)[A-Z0-9]+-\\d+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        // with added '$' and '.' to exclude strings that look similar to Jira issues, e.g. `text that may cause confusion: $foo-1 or test.TST-01.com`
+        private static readonly Regex Expression = new Regex("((?<!([A-Z0-9\\$\\.]{1,10})-?)[A-Z0-9]+-\\d+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         
         public string[] ParseWorkItemIds(OctopusPackageMetadata packageMetadata)
         {

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -30,7 +30,10 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems
 
         public SuccessOrErrorResult<WorkItemLink[]> Map(OctopusPackageMetadata packageMetadata)
         {
-            if (packageMetadata.CommentParser != CommentParser)
+
+            if (!IsEnabled || 
+                string.IsNullOrEmpty(store.GetJiraUsername()) || 
+                string.IsNullOrEmpty(store.GetJiraPassword()))
                 return null;
 
             var baseUrl = store.GetBaseUrl();

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -51,7 +51,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems
                 return new WorkItemLink
                 {
                     Id = workItemId,
-                    Description = GetReleaseNote(issue, workItemId, releaseNotePrefix),
+                    Description = GetReleaseNote(issue, releaseNotePrefix),
                     LinkUrl = baseUrl + "/browse/" + workItemId
                 };
             })
@@ -59,18 +59,18 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems
             .ToArray();
         }
 
-        public string GetReleaseNote(JiraIssue issue, string workItemId, string releaseNotePrefix)
+        public string GetReleaseNote(JiraIssue issue, string releaseNotePrefix)
         {
             if (issue.Fields.Comments.Total == 0 || string.IsNullOrWhiteSpace(releaseNotePrefix))
                 return issue.Fields.Summary;
 
             var releaseNoteRegex = new Regex($"^{releaseNotePrefix}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            var issueComments = jira.Value.GetIssueComments(workItemId).Result;
+            var issueComments = jira.Value.GetIssueComments(issue.Key).Result;
 
             var releaseNote = issueComments?.Comments.LastOrDefault(c => releaseNoteRegex.IsMatch(c.Body))?.Body;
             return !string.IsNullOrWhiteSpace(releaseNote)
                 ? releaseNoteRegex.Replace(releaseNote, "")?.Trim()
-                : issue.Fields.Summary ?? workItemId;
+                : issue.Fields.Summary ?? issue.Key;
         }
     }
 }


### PR DESCRIPTION
This PR changes the following behaviors of the Jira extension:

- We only display work items if:
  - The extension is enabled, and
  - Username/Password has been configured
- Less restrictive issue parsing from comments
- Only include issues that exists in the configured Jira instance

![image](https://user-images.githubusercontent.com/1035315/61519734-fcaf5c80-aa4f-11e9-919d-9b7199133376.png)

Fixes #12 