### PR TITLE
Ignore Jira refs followed by alpha chars and simplify

### DIFF
--- a/source/Server.Tests/CommentParserScenarios.cs
+++ b/source/Server.Tests/CommentParserScenarios.cs
@@ -141,6 +141,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
         [TestCase("Some text test-foo-2-bar")]
         [TestCase("Some text test-foo-")]
         [TestCase("Something $foo-1")]
+        [TestCase("Ignore refs followed by alpha chars Feature-0day")]
         // Due to relaxing the RegEx used to parse issues from comments this test case is no longer valid,
         // it's handled by us checking with the Jira instance if the issue exists, or if it doesnt exist
         // it doesn't get included in the list of work items returned to the UI

--- a/source/Server/WorkItems/CommentParser.cs
+++ b/source/Server/WorkItems/CommentParser.cs
@@ -8,7 +8,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems
     {
         // Expression based on example found here https://confluence.atlassian.com/stashkb/integrating-with-custom-jira-issue-key-313460921.html?_ga=2.163394108.1696841245.1556699049-1954949426.1532303954 with modified negative lookbehind
         // with added '$' and '.' to exclude strings that look similar to Jira issues, e.g. `text that may cause confusion: $foo-1 or test.TST-01.com`
-        private static readonly Regex Expression = new Regex("((?<!([A-Z0-9\\$\\.]{1,10})-?)[A-Z0-9]+-\\d+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex Expression = new Regex("(?<![A-Z0-9\\$\\.]-?)(?>[A-Z0-9]+-\\d+)(?![A-Z])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         
         public string[] ParseWorkItemIds(OctopusPackageMetadata packageMetadata)
         {


### PR DESCRIPTION
**The comment "Ignore refs followed by alpha chars Feature-0day" shouldn't return "Feature-0"**

Add negative lookahead so we can ignore refs immediately followed by an alpha char
`((?<!([A-Z0-9\\$\\.]{1,10})-?)[A-Z0-9]+-\\d+(?![A-Z]))`

Add an atomic group so we don't give back and get "TEST-12" from "TEST-123abc"
`((?<!([A-Z0-9\\$\\.]{1,10})-?)(?>[A-Z0-9]+-\\d+)(?![A-Z]))`

**Simplify**

Remove the 1-10 quantifier since [Jira now allows projects with longer names](https://jira.atlassian.com/browse/JRASERVER-28577) and because it doesn't seem to work anyway (not even sure if this is why Stash put this in here)
`((?<!([A-Z0-9\\$\\.])-?)(?>[A-Z0-9]+-\\d+)(?![A-Z]))`

Remove the capturing group inside the negative lookbehind (I think this is supposed to be non-capturing)
`((?<![A-Z0-9\\$\\.]-?)(?>[A-Z0-9]+-\\d+)(?![A-Z]))`

Remove the group surrounding the entire regex since we match with the new atomic group
`(?<![A-Z0-9\\$\\.]-?)(?>[A-Z0-9]+-\\d+)(?![A-Z])`


