### PR TITLE
renaming PackageMetadata and changing the way the commentParser works

### DIFF
--- a/source/Client/Client.csproj
+++ b/source/Client/Client.csproj
@@ -14,6 +14,6 @@
     <PackageProjectUrl>https://github.com/OctopusDeploy/JiraIssueTracker</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Client" Version="6.3.2" />
+    <PackageReference Include="Octopus.Client" Version="7.2.0" />
   </ItemGroup>
 </Project>

--- a/source/Server.Tests/CommentParserScenarios.cs
+++ b/source/Server.Tests/CommentParserScenarios.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using NUnit.Framework;
 using Octopus.Server.Extensibility.HostServices.Model.IssueTrackers;
-using Octopus.Server.Extensibility.HostServices.Model.PackageMetadata;
+using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems;
 
 namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
@@ -153,9 +153,9 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
             Assert.IsEmpty(workItemReferences);
         }
         
-        private OctopusPackageMetadata Create(string comment)
+        private OctopusBuildInformation Create(string comment)
         {
-            return new OctopusPackageMetadata
+            return new OctopusBuildInformation
             {
                 Commits = new[] { new Commit{ Id = "a", Comment = comment }}
             };

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.3-enh-buildinforen0004" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.0" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 </Project>

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.3-enh-buildinforen0004" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 </Project>

--- a/source/Server/Deployments/DeploymentObserver.cs
+++ b/source/Server/Deployments/DeploymentObserver.cs
@@ -64,8 +64,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Deployments
         {
             if (!store.GetIsEnabled() ||
                 store.GetJiraInstanceType() == JiraInstanceType.Server ||
-                domainEvent.Deployment.Changes.All(drn => drn.VersionMetadata.All(pm => pm.CommentParser != JiraConfigurationStore.CommentParser)) ||
-                domainEvent.Deployment.Changes.All(drn => drn.VersionMetadata.All(pm => !pm.WorkItems.Any())))
+                domainEvent.Deployment.Changes.All(drn => drn.VersionBuildInformation.All(pm => pm.WorkItems.All(wi => wi.Source != JiraConfigurationStore.CommentParser))))
                 return;
 
             using (log.OpenBlock($"Sending Jira state update - {StateFromEventType(domainEvent.EventType)}"))
@@ -125,9 +124,9 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Deployments
                             DeploymentSequenceNumber = int.Parse(deployment.Id.Split('-')[1]),
                             UpdateSequenceNumber = DateTime.UtcNow.Ticks,
                             DisplayName = serverTask.Description,
-                            IssueKeys = deployment.Changes.SelectMany(drn => drn.VersionMetadata
-                                .Where(pm => pm.CommentParser == JiraConfigurationStore.CommentParser)
+                            IssueKeys = deployment.Changes.SelectMany(drn => drn.VersionBuildInformation
                                 .SelectMany(pm => pm.WorkItems)
+                                .Where(wi => wi.Source == JiraConfigurationStore.CommentParser)
                                 .Select(wi => wi.Id)
                                 .Distinct()).ToArray(),
                             Url =

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Octopus.Data" Version="4.2.1" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.3-enh-buildinforen0004" />
     <PackageReference Include="Octopus.Time" Version="1.1.6" />
   </ItemGroup>
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Octopus.Data" Version="4.2.1" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.3-enh-buildinforen0004" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.0" />
     <PackageReference Include="Octopus.Time" Version="1.1.6" />
   </ItemGroup>
 </Project>

--- a/source/Server/WorkItems/CommentParser.cs
+++ b/source/Server/WorkItems/CommentParser.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using System.Text.RegularExpressions;
-using Octopus.Server.Extensibility.HostServices.Model.PackageMetadata;
+using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 
 namespace Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems
 {
@@ -10,9 +10,9 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems
         // with added '$' and '.' to exclude strings that look similar to Jira issues, e.g. `text that may cause confusion: $foo-1 or test.TST-01.com`
         private static readonly Regex Expression = new Regex("(?<![A-Z0-9\\$\\.]-?)(?>[A-Z0-9]+-\\d+)(?![A-Z])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         
-        public string[] ParseWorkItemIds(OctopusPackageMetadata packageMetadata)
+        public string[] ParseWorkItemIds(OctopusBuildInformation buildInformation)
         {
-            return packageMetadata.Commits.SelectMany(c => WorkItemIds(c.Comment))
+            return buildInformation.Commits.SelectMany(c => WorkItemIds(c.Comment))
                 .Where(workItemId => !string.IsNullOrWhiteSpace(workItemId))
                 .ToArray();
         }


### PR DESCRIPTION
Relates to OctopusDeploy/Issues#5885